### PR TITLE
Fix failure due to source folder missing

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -129,7 +129,7 @@ _package() {
     DEPMOD=/doesnt/exist modules_install  # Suppress depmod
 
   # remove build and source links
-  rm "$modulesdir"/{source,build}
+  rm -f "$modulesdir"/{source,build}
 }
 
 _package-headers() {


### PR DESCRIPTION
Adds `-f` to ignore missing folders during rm, this brings the pkgbuild back in line with linux-git.